### PR TITLE
Chunking

### DIFF
--- a/api/chunking.go
+++ b/api/chunking.go
@@ -12,16 +12,19 @@ const (
 //chunkMagic uint32 = 0xF114
 )
 
-// StreamHeader manifest for a chunked transfer
+// StreamHeader manifest for a chunked transfer (database version)
 type StreamHeader struct {
-	StreamID  uint32
-	NumChunks uint32
+	StreamID    uint32 `db:"streamid"`
+	NumChunks   uint32 `db:"parts"`
+	ChannelName string `db:"channel"`
+	Pubkey      string `db:"pubkey"`
 }
 
-// ChunkHeader header for each chunk
-type ChunkHeader struct {
-	StreamID uint32
-	ChunkNum uint32
+// Chunk header for each chunk
+type Chunk struct {
+	StreamID uint32 `db:"streamid"`
+	ChunkNum uint32 `db:"chunknum"`
+	Data     []byte `db:"data"`
 }
 
 // ChunkSize - calculates the minimum chunk size from all active transports

--- a/api/chunking.go
+++ b/api/chunking.go
@@ -7,11 +7,6 @@ import (
 	"github.com/awgh/bencrypt/bc"
 )
 
-const (
-//hdrMagic   uint32 = 0xF113
-//chunkMagic uint32 = 0xF114
-)
-
 // StreamHeader manifest for a chunked transfer (database version)
 type StreamHeader struct {
 	StreamID    uint32 `db:"streamid"`
@@ -86,42 +81,3 @@ func SendChunked(node Node, chunkSize uint32, msg Msg) (err error) {
 	}
 	return
 }
-
-/*
-// ReadChunked - utility function to rebuild chunks into the original buffer
-// 					returns: ended (bool) - true when last chunk has been read
-//							 Msg - set to the reconstructed message, only set when ended is true
-func ReadChunked(chunks *map[int][]byte, rxMsgBuffer *api.Msg) (bool, *Msg) {
-	rxMsg := new(Msg)
-	var chunkId uint32
-	binary.Read(rxMsgBuffer.Content, binary.LittleEndian, &chunkId)
-	log.Printf("chunkId read at server: %x  len(rx): %d\n", chunkId, rxMsgBuffer.Content.Len())
-
-	if chunkId != 0xFFFFFFFF {
-		(*chunks)[int(chunkId)] = rxMsgBuffer.Content.Bytes()
-		log.Println("chunkId cached", chunkId)
-		return false, nil
-	}
-	// re-assemble johnny 5
-	var buf bytes.Buffer
-	var keys []int
-	for k, _ := range *chunks {
-		keys = append(keys, k)
-	}
-	sort.Ints(keys)
-	for _, k := range keys {
-		log.Println("reassembled chunk", k)
-		buf.Write((*chunks)[k])
-	}
-	log.Println("reassembled remainder")
-	buf.Write(rxMsgBuffer.Content.Bytes())
-
-	//Use default gob decoder
-	dec := gob.NewDecoder(bytes.NewReader(buf.Bytes()))
-	if err := dec.Decode(&rxMsg); err != nil {
-		log.Println("[INCOMING MSG ERR c2 224]:", err.Error(), rxMsg, rxMsgBuffer)
-	}
-	//chunks = new(map[int][]byte)
-	return true, rxMsg
-}
-*/

--- a/api/chunking.go
+++ b/api/chunking.go
@@ -12,7 +12,6 @@ type StreamHeader struct {
 	StreamID    uint32 `db:"streamid"`
 	NumChunks   uint32 `db:"parts"`
 	ChannelName string `db:"channel"`
-	Pubkey      string `db:"pubkey"`
 }
 
 // Chunk header for each chunk

--- a/api/chunking.go
+++ b/api/chunking.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/awgh/bencrypt/bc"
+)
+
+const (
+//hdrMagic   uint32 = 0xF113
+//chunkMagic uint32 = 0xF114
+)
+
+// StreamHeader manifest for a chunked transfer
+type StreamHeader struct {
+	StreamID  uint32
+	NumChunks uint32
+}
+
+// ChunkHeader header for each chunk
+type ChunkHeader struct {
+	StreamID uint32
+	ChunkNum uint32
+}
+
+// ChunkSize - calculates the minimum chunk size from all active transports
+func ChunkSize(node Node) uint32 {
+	var chunksize uint32 = 64 * 1024
+	policies := node.GetPolicies()
+	for _, p := range policies {
+		limit := uint32(p.GetTransport().ByteLimit())
+		if limit < chunksize {
+			chunksize = limit
+		}
+	}
+	return chunksize
+}
+
+// SendChunked - utility function to break large messages into smaller ones for transports that can't handle arbitrarily large messages
+func SendChunked(node Node, chunkSize uint32, msg Msg) (err error) {
+
+	buf := msg.Content.Bytes()
+	buflen := uint32(len(buf))
+
+	wholeLoops := buflen / chunkSize
+	remainder := buflen % chunkSize
+	totalChunks := wholeLoops
+	if remainder != 0 {
+		totalChunks++
+	}
+
+	var streamID []byte
+	if wholeLoops+remainder != 0 { // we're sending something, send stream header
+		streamID, err = bc.GenerateRandomBytes(4)
+		if err != nil {
+			return
+		}
+		b := bytes.NewBuffer(streamID)                            // StreamID
+		binary.Write(b, binary.LittleEndian, uint32(totalChunks)) // NumChunks
+		if err = node.SendMsg(Msg{Name: msg.Name, Content: b, IsChan: msg.IsChan, PubKey: msg.PubKey, Chunked: true}); err != nil {
+			return
+		}
+		for i := uint32(0); i < wholeLoops; i++ {
+			b := bytes.NewBuffer(streamID)                  // StreamID
+			binary.Write(b, binary.LittleEndian, uint32(i)) // ChunkNum
+			b.Write(buf[i*chunkSize : (i*chunkSize)+chunkSize])
+			//log.Println("chunk loop", i, buflen, len(tbuf))
+			if err = node.SendMsg(Msg{Name: msg.Name, Content: b, IsChan: msg.IsChan, PubKey: msg.PubKey, Chunked: true}); err != nil {
+				return
+			}
+		}
+		if remainder > 0 {
+			b := bytes.NewBuffer(streamID)                           // StreamID
+			binary.Write(b, binary.LittleEndian, uint32(wholeLoops)) // ChunkNum
+			b.Write(buf[wholeLoops*chunkSize:])
+			//log.Println("chunk remainder", len(buf[wholeLoops*chunkSize:]))
+			if err = node.SendMsg(Msg{Name: msg.Name, Content: b, IsChan: msg.IsChan, PubKey: msg.PubKey, Chunked: true}); err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+/*
+// ReadChunked - utility function to rebuild chunks into the original buffer
+// 					returns: ended (bool) - true when last chunk has been read
+//							 Msg - set to the reconstructed message, only set when ended is true
+func ReadChunked(chunks *map[int][]byte, rxMsgBuffer *api.Msg) (bool, *Msg) {
+	rxMsg := new(Msg)
+	var chunkId uint32
+	binary.Read(rxMsgBuffer.Content, binary.LittleEndian, &chunkId)
+	log.Printf("chunkId read at server: %x  len(rx): %d\n", chunkId, rxMsgBuffer.Content.Len())
+
+	if chunkId != 0xFFFFFFFF {
+		(*chunks)[int(chunkId)] = rxMsgBuffer.Content.Bytes()
+		log.Println("chunkId cached", chunkId)
+		return false, nil
+	}
+	// re-assemble johnny 5
+	var buf bytes.Buffer
+	var keys []int
+	for k, _ := range *chunks {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	for _, k := range keys {
+		log.Println("reassembled chunk", k)
+		buf.Write((*chunks)[k])
+	}
+	log.Println("reassembled remainder")
+	buf.Write(rxMsgBuffer.Content.Bytes())
+
+	//Use default gob decoder
+	dec := gob.NewDecoder(bytes.NewReader(buf.Bytes()))
+	if err := dec.Decode(&rxMsg); err != nil {
+		log.Println("[INCOMING MSG ERR c2 224]:", err.Error(), rxMsg, rxMsgBuffer)
+	}
+	//chunks = new(map[int][]byte)
+	return true, rxMsg
+}
+*/

--- a/api/chunking.go
+++ b/api/chunking.go
@@ -33,7 +33,11 @@ func ChunkSize(node Node) uint32 {
 			chunksize = limit
 		}
 	}
-	return chunksize
+	if chunksize <= 132 {
+		log.Fatal("Transport has invalid low byte limit")
+	}
+
+	return chunksize - 132 //todo: this is the overhead for ECC, what about RSA?
 }
 
 // SendChunked - utility function to break large messages into smaller ones for transports that can't handle arbitrarily large messages

--- a/api/msg.go
+++ b/api/msg.go
@@ -8,8 +8,10 @@ import (
 
 // Msg : object that describes the messages passed between nodes
 type Msg struct {
-	Name    string
-	Content *bytes.Buffer
-	IsChan  bool
-	PubKey  bc.PubKey
+	Name         string
+	Content      *bytes.Buffer
+	IsChan       bool
+	PubKey       bc.PubKey
+	Chunked      bool
+	StreamHeader bool
 }

--- a/api/node.go
+++ b/api/node.go
@@ -18,6 +18,12 @@ type Node interface {
 	Handle(msg Msg) (bool, error)
 	Forward(msg Msg) error
 
+	// Chunking
+	// AddStream - inform node of receipt of a stream header
+	AddStream(streamID uint32, totalChunks uint32, channelName string) error
+	// AddChunk - inform node of receipt of a chunk
+	AddChunk(streamID uint32, chunkNum uint32, data []byte) error
+
 	// FlushOutbox : Empties the outbox of messages older than maxAgeSeconds
 	FlushOutbox(maxAgeSeconds int64)
 

--- a/api/node.go
+++ b/api/node.go
@@ -15,8 +15,8 @@ type Node interface {
 	Router() Router
 	SetRouter(router Router)
 	GetChannelPrivKey(name string) (string, error)
-	Handle(channelName string, message []byte) (bool, error)
-	Forward(channelName string, message []byte) error
+	Handle(msg Msg) (bool, error)
+	Forward(msg Msg) error
 
 	// FlushOutbox : Empties the outbox of messages older than maxAgeSeconds
 	FlushOutbox(maxAgeSeconds int64)
@@ -87,10 +87,13 @@ type Node interface {
 	// DeletePeer : Remove a peer from this node's database (33)
 	DeletePeer(name string) error
 
-	// Send : Transmit a message to a single key (34)
+	// Send : Transmit a message to a single key (34) <deprecated>
 	Send(contactName string, data []byte, pubkey ...bc.PubKey) error
-	// SendChannel : Transmit a message to a channel (35)
+	// SendChannel : Transmit a message to a channel (35) <deprecated>
 	SendChannel(channelName string, data []byte, pubkey ...bc.PubKey) error
+
+	// SendMsg : Transmit a message object (36)
+	SendMsg(msg Msg) error
 
 	//  End of Admin API Functions
 

--- a/api/router.go
+++ b/api/router.go
@@ -18,3 +18,12 @@ type Patch struct {
 	From string
 	To   []string
 }
+
+const (
+	// StreamHeaderFlag : this message is a stream header
+	StreamHeaderFlag = 0x01
+	// ChunkedFlag : this message is a chunked
+	ChunkedFlag = 0x02
+	// ChannelFlag : this message has a channel name prefix
+	ChannelFlag = 0x04
+)

--- a/nodes/db/admin.go
+++ b/nodes/db/admin.go
@@ -199,10 +199,6 @@ func (node *Node) SendMsg(msg api.Msg) error {
 		return err
 	}
 
-	if msg.StreamHeader {
-		log.Println("Sent Msg after encrypt:", msg.Content.Bytes(), data)
-	}
-
 	flags := uint8(0)
 	if msg.IsChan {
 		flags |= api.ChannelFlag
@@ -224,9 +220,6 @@ func (node *Node) SendMsg(msg api.Msg) error {
 	data = append(rxsum, data...)
 	ts := time.Now().UnixNano()
 
-	if msg.StreamHeader {
-		log.Println("Sent Msg:", msg.Content.Bytes(), data)
-	}
 	if msg.IsChan {
 		return node.dbOutboxEnqueue(msg.Name, data, ts, false)
 	}

--- a/nodes/db/admin.go
+++ b/nodes/db/admin.go
@@ -190,8 +190,8 @@ func (node *Node) SendMsg(msg api.Msg) error {
 	channelNameLen := uint32(0)
 	if msg.IsChan {
 		channelNameLen = uint32(len(msg.Name))
+		chunkSize -= (channelNameLen + 2) // +2 for channel length prefix
 	}
-	chunkSize -= (channelNameLen + 2) // +2 for channel length prefix
 
 	if msg.Content.Len() > 0 && uint32(msg.Content.Len()) > chunkSize { // we need to chunk
 		if msg.Chunked { // we're already chunked, freak out!

--- a/nodes/db/admin.go
+++ b/nodes/db/admin.go
@@ -185,19 +185,12 @@ func (node *Node) SendChannel(channelName string, data []byte, pubkey ...bc.PubK
 func (node *Node) SendMsg(msg api.Msg) error {
 
 	// determine if we need to chunk
-	chunkSize := api.ChunkSize(node)
-	chunkSize -= (96 + 1) // todo: 96 is hardcoded overhead from assuming ECC but this needs an abstract method, +1 for flags
-	channelNameLen := uint32(0)
-	if msg.IsChan {
-		channelNameLen = uint32(len(msg.Name))
-		chunkSize -= (channelNameLen + 2) // +2 for channel length prefix
-	}
-
+	chunkSize := api.ChunkSize(node)                                    // finds the minimum transport byte limit
 	if msg.Content.Len() > 0 && uint32(msg.Content.Len()) > chunkSize { // we need to chunk
 		if msg.Chunked { // we're already chunked, freak out!
 			return errors.New("Chunked message needs to be chunked, bailing out")
 		}
-		return api.SendChunked(node, chunkSize, msg)
+		return api.SendChunked(node, chunkSize-8, msg)
 	}
 
 	data, err := node.contentKey.EncryptMessage(msg.Content.Bytes(), msg.PubKey)

--- a/nodes/db/admin.go
+++ b/nodes/db/admin.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"errors"
 	"log"
 	"strings"
@@ -157,8 +158,7 @@ func (node *Node) Send(contactName string, data []byte, pubkey ...bc.PubKey) err
 			return err
 		}
 	}
-
-	return node.send("", destkey, data)
+	return node.SendMsg(api.Msg{Name: contactName, Content: bytes.NewBuffer(data), IsChan: false, PubKey: destkey, Chunked: false})
 }
 
 // SendChannel : Transmit a message to a channel
@@ -178,25 +178,57 @@ func (node *Node) SendChannel(channelName string, data []byte, pubkey ...bc.PubK
 	if destkey == nil {
 		log.Fatal("nil DestKey in SendChannel")
 	}
-
-	return node.send(channelName, destkey, data)
+	return node.SendMsg(api.Msg{Name: channelName, Content: bytes.NewBuffer(data), IsChan: true, PubKey: destkey, Chunked: false})
 }
 
-func (node *Node) send(channelName string, destkey bc.PubKey, msg []byte) error {
+// SendMsg : Transmits a message
+func (node *Node) SendMsg(msg api.Msg) error {
 
-	data, err := node.contentKey.EncryptMessage(msg, destkey)
+	// determine if we need to chunk
+	chunkSize := api.ChunkSize(node)
+	chunkSize -= (96 + 1) // todo: 96 is hardcoded overhead from assuming ECC but this needs an abstract method, +1 for flags
+	channelNameLen := uint32(0)
+	if msg.IsChan {
+		channelNameLen = uint32(len(msg.Name))
+	}
+	chunkSize -= (channelNameLen + 2) // +2 for channel length prefix
+
+	if msg.Content.Len() > 0 && uint32(msg.Content.Len()) > chunkSize { // we need to chunk
+		if msg.Chunked { // we're already chunked, freak out!
+			return errors.New("Chunked message needs to be chunked, bailing out")
+		}
+		return api.SendChunked(node, chunkSize, msg)
+	}
+
+	data, err := node.contentKey.EncryptMessage(msg.Content.Bytes(), msg.PubKey)
 	if err != nil {
 		return err
 	}
 
-	// prepend a uint16 of channel name length, little-endian
-	t := uint16(len(channelName))
-	rxsum := []byte{byte(t >> 8), byte(t & 0xFF)}
-	rxsum = append(rxsum, []byte(channelName)...)
-	data = append(rxsum, data...)
+	flags := uint8(0)
+	if msg.IsChan {
+		flags |= api.ChannelFlag
+	}
+	if msg.Chunked {
+		flags |= api.ChunkedFlag
+	}
+	if msg.StreamHeader {
+		flags |= api.StreamHeaderFlag
+	}
+	rxsum := []byte{flags} // prepend flags byte
 
+	if msg.IsChan {
+		// prepend a uint16 of channel name length, little-endian
+		t := uint16(len(msg.Name))
+		rxsum = append(rxsum, byte(t>>8), byte(t&0xFF))
+		rxsum = append(rxsum, []byte(msg.Name)...)
+	}
+	data = append(rxsum, data...)
 	ts := time.Now().UnixNano()
-	return node.dbOutboxEnqueue(channelName, data, ts, false) // todo: not checking if exists here?
+	if msg.IsChan {
+		return node.dbOutboxEnqueue(msg.Name, data, ts, false)
+	}
+	return node.dbOutboxEnqueue("", data, ts, false)
 }
 
 // SendBulk : Transmit messages to a single key

--- a/nodes/db/database.go
+++ b/nodes/db/database.go
@@ -410,7 +410,7 @@ func (node *Node) dbClearStream(streamID uint32) error {
 	return res.Delete()
 }
 
-func (node *Node) dbAddStream(streamID uint32, totalChunks uint32, channelName string) error {
+func (node *Node) AddStream(streamID uint32, totalChunks uint32, channelName string) error {
 	col := node.db.Collection("streams")
 	res := col.Find().Where("streamid = ?", streamID)
 	count, err := res.Count()
@@ -437,7 +437,7 @@ func (node *Node) dbAddStream(streamID uint32, totalChunks uint32, channelName s
 	return res.Update(stream)
 }
 
-func (node *Node) dbAddChunk(streamID uint32, chunkNum uint32, data []byte) error {
+func (node *Node) AddChunk(streamID uint32, chunkNum uint32, data []byte) error {
 	col := node.db.Collection("chunks")
 	res := col.Find().Where("streamid = ?", streamID).And("chunknum = ?", chunkNum)
 	count, err := res.Count()

--- a/nodes/db/database.go
+++ b/nodes/db/database.go
@@ -409,6 +409,7 @@ func (node *Node) dbGetMessages(lastTime, maxBytes int64, channelNames ...string
 		offset += rowsPerRequest
 		args[len(args)-1] = offset
 	}
+	log.Println("last time/returned:", lastTime, lastTimeReturned)
 	return msgs, lastTimeReturned, nil
 }
 

--- a/nodes/db/database.go
+++ b/nodes/db/database.go
@@ -422,7 +422,7 @@ func (node *Node) dbClearStream(streamID uint32) error {
 	return res.Delete()
 }
 
-func (node *Node) dbAddStream(streamID uint32, totalChunks uint32, channelName string, pubkey string) error {
+func (node *Node) dbAddStream(streamID uint32, totalChunks uint32, channelName string) error {
 	col := node.db.Collection("streams")
 	res := col.Find().Where("streamid = ?", streamID)
 	count, err := res.Count()
@@ -435,7 +435,6 @@ func (node *Node) dbAddStream(streamID uint32, totalChunks uint32, channelName s
 		stream.StreamID = streamID
 		stream.NumChunks = totalChunks
 		stream.ChannelName = channelName
-		stream.Pubkey = pubkey
 		_, err = col.Insert(stream)
 		return err
 	}
@@ -447,7 +446,6 @@ func (node *Node) dbAddStream(streamID uint32, totalChunks uint32, channelName s
 	stream.StreamID = streamID
 	stream.NumChunks = totalChunks
 	stream.ChannelName = channelName
-	stream.Pubkey = pubkey
 	return res.Update(stream)
 }
 
@@ -613,10 +611,9 @@ func (node *Node) BootstrapDB(dbAdapter, dbConnectionString string) sqlbuilder.D
 	CREATE TABLE IF NOT EXISTS streams (		
 		streamid		%s	NOT NULL,
 		parts			%s	NOT NULL,
-		channel			%s	NOT NULL,
-		pubkey			%s	NOT NULL
+		channel			%s	NOT NULL
 	);
-	`, int64Name, int64Name, strName, strName))
+	`, int64Name, int64Name, strName))
 	checkErr(err)
 
 	// Content Key Setup

--- a/nodes/db/database.go
+++ b/nodes/db/database.go
@@ -611,9 +611,11 @@ func (node *Node) BootstrapDB(dbAdapter, dbConnectionString string) sqlbuilder.D
 	_, err = node.db.Exec(fmt.Sprintf(`
 	CREATE TABLE IF NOT EXISTS streams (		
 		streamid		%s	NOT NULL,
-		parts			%s	NOT NULL		
+		parts			%s	NOT NULL,
+		channel			%s	NOT NULL,
+		pubkey			%s	NOT NULL
 	);
-	`, int64Name, int64Name))
+	`, int64Name, int64Name, strName, strName))
 	checkErr(err)
 
 	// Content Key Setup

--- a/nodes/db/internal.go
+++ b/nodes/db/internal.go
@@ -91,8 +91,12 @@ func (node *Node) HandleChunk(msg api.Msg) error {
 	if msg.StreamHeader {
 		// save totalChunks by streamID
 		var streamID, totalChunks uint32
-		binary.Read(msg.Content, binary.LittleEndian, &streamID)
-		binary.Read(msg.Content, binary.LittleEndian, &totalChunks)
+		//if msg.Content.Len() != 8 {2019/08/15 10:43:51 Dropoff decoded: [
+		//	log.Fatal("something is messed up")
+		//}
+		tmpb := bytes.NewBuffer(msg.Content.Bytes()[:8])
+		binary.Read(tmpb, binary.LittleEndian, &streamID)
+		binary.Read(tmpb, binary.LittleEndian, &totalChunks)
 		channel := ""
 		if msg.IsChan {
 			channel = msg.Name
@@ -105,8 +109,9 @@ func (node *Node) HandleChunk(msg api.Msg) error {
 	} else if msg.Chunked {
 		// save chunk
 		var streamID, chunkNum uint32
-		binary.Read(msg.Content, binary.LittleEndian, &streamID)
-		binary.Read(msg.Content, binary.LittleEndian, &chunkNum)
+		tmpb := bytes.NewBuffer(msg.Content.Bytes()[:8])
+		binary.Read(tmpb, binary.LittleEndian, &streamID)
+		binary.Read(tmpb, binary.LittleEndian, &chunkNum)
 		data, err := ioutil.ReadAll(msg.Content)
 		if err != nil {
 			return err

--- a/nodes/db/internal.go
+++ b/nodes/db/internal.go
@@ -97,7 +97,11 @@ func (node *Node) HandleChunk(msg api.Msg) error {
 		if msg.IsChan {
 			channel = msg.Name
 		}
-		return node.dbAddStream(streamID, totalChunks, channel, msg.PubKey.ToB64())
+		pk := ""
+		if msg.PubKey != nil {
+			pk = msg.PubKey.ToB64()
+		}
+		return node.dbAddStream(streamID, totalChunks, channel, pk)
 	} else if msg.Chunked {
 		// save chunk
 		var streamID, chunkNum uint32

--- a/nodes/db/public.go
+++ b/nodes/db/public.go
@@ -37,8 +37,6 @@ func (node *Node) Dropoff(bundle api.Bundle) error {
 		return erra
 	}
 
-	log.Printf("Dropoff decoded: %+v\n", msgs)
-
 	for i := 0; i < len(msgs); i++ {
 		if len(msgs[i]) < 16 { // aes.BlockSize == 16
 			continue //todo: remove padding before here?
@@ -62,11 +60,11 @@ func (node *Node) Pickup(rpub bc.PubKey, lastTime int64, maxBytes int64, channel
 	if err != nil {
 		return retval, err
 	}
-	log.Printf("maxBytes = %d", maxBytes)
+	//log.Printf("maxBytes = %d", maxBytes)
 
 	// Return things
 
-	log.Printf("rows returned by Pickup query: %d, lastTime: %d\n", len(msgs), lastTimeReturned)
+	//log.Printf("rows returned by Pickup query: %d, lastTime: %d\n", len(msgs), lastTimeReturned)
 	retval.Time = lastTimeReturned
 	if len(msgs) > 0 {
 		//use default gob encoder

--- a/nodes/db/public.go
+++ b/nodes/db/public.go
@@ -36,6 +36,9 @@ func (node *Node) Dropoff(bundle api.Bundle) error {
 		log.Printf("dropoff gob decode failed, len %d\n", len(data))
 		return erra
 	}
+
+	log.Printf("Dropoff decoded: %+v\n", msgs)
+
 	for i := 0; i < len(msgs); i++ {
 		if len(msgs[i]) < 16 { // aes.BlockSize == 16
 			continue //todo: remove padding before here?
@@ -59,11 +62,11 @@ func (node *Node) Pickup(rpub bc.PubKey, lastTime int64, maxBytes int64, channel
 	if err != nil {
 		return retval, err
 	}
-	//log.Printf("maxBytes = %d, bytesRead = %d\n", maxBytes, bytesRead)
+	log.Printf("maxBytes = %d", maxBytes)
 
 	// Return things
 
-	//log.Printf("rows returned by Pickup query: %d, lastTime: %d\n", len(msgs), lastTimeReturned)
+	log.Printf("rows returned by Pickup query: %d, lastTime: %d\n", len(msgs), lastTimeReturned)
 	retval.Time = lastTimeReturned
 	if len(msgs) > 0 {
 		//use default gob encoder

--- a/nodes/fs/admin.go
+++ b/nodes/fs/admin.go
@@ -273,14 +273,7 @@ func (node *Node) SendChannel(channelName string, data []byte, pubkey ...bc.PubK
 func (node *Node) SendMsg(msg api.Msg) error {
 
 	// determine if we need to chunk
-	chunkSize := api.ChunkSize(node)
-	chunkSize -= (96 + 1) // todo: 96 is hardcoded overhead from assuming ECC but this needs an abstract method, +1 for flags
-	channelNameLen := uint32(0)
-	if msg.IsChan {
-		channelNameLen = uint32(len(msg.Name))
-		chunkSize -= (channelNameLen + 2) // +2 for channel length prefix
-	}
-
+	chunkSize := api.ChunkSize(node)                                    // finds the minimum transport byte limit
 	if msg.Content.Len() > 0 && uint32(msg.Content.Len()) > chunkSize { // we need to chunk
 		if msg.Chunked { // we're already chunked, freak out!
 			return errors.New("Chunked message needs to be chunked, bailing out")

--- a/nodes/fs/admin.go
+++ b/nodes/fs/admin.go
@@ -278,8 +278,8 @@ func (node *Node) SendMsg(msg api.Msg) error {
 	channelNameLen := uint32(0)
 	if msg.IsChan {
 		channelNameLen = uint32(len(msg.Name))
+		chunkSize -= (channelNameLen + 2) // +2 for channel length prefix
 	}
-	chunkSize -= (channelNameLen + 2) // +2 for channel length prefix
 
 	if msg.Content.Len() > 0 && uint32(msg.Content.Len()) > chunkSize { // we need to chunk
 		if msg.Chunked { // we're already chunked, freak out!

--- a/nodes/fs/admin.go
+++ b/nodes/fs/admin.go
@@ -361,19 +361,11 @@ func (node *Node) Start() error {
 			if !node.isRunning {
 				break
 			}
-
 			// read message off the input channel
 			message := <-node.In()
 			node.debugMsg("Message accepted on input channel")
-			switch message.IsChan {
-			case true:
-				if err := node.SendChannel(message.Name, message.Content.Bytes(), message.PubKey); err != nil {
-					log.Fatal("SendChannel failed in input loop")
-				}
-			case false:
-				if err := node.Send(message.Name, message.Content.Bytes(), message.PubKey); err != nil {
-					log.Fatal("Send failed in input loop")
-				}
+			if err := node.SendMsg(message); err != nil {
+				log.Fatal(err)
 			}
 		}
 	}()

--- a/nodes/fs/fsnode.go
+++ b/nodes/fs/fsnode.go
@@ -40,6 +40,8 @@ type Node struct {
 	contacts map[string]*api.Contact
 	peers    map[string]*api.Peer
 	profiles map[string]*api.ProfilePriv
+	streams  map[uint32]*api.StreamHeader
+	chunks   map[uint32]map[uint32]*api.Chunk
 
 	//outbox   []*outboxMsg
 	basePath    string
@@ -57,6 +59,8 @@ func New(contentKey, routingKey bc.KeyPair, basePath string) *Node {
 	node.contacts = make(map[string]*api.Contact)
 	node.peers = make(map[string]*api.Peer)
 	node.profiles = make(map[string]*api.ProfilePriv)
+	node.streams = make(map[uint32]*api.StreamHeader)
+	node.chunks = make(map[uint32]map[uint32]*api.Chunk)
 
 	// set crypto modes
 	node.contentKey = contentKey

--- a/nodes/fs/internal.go
+++ b/nodes/fs/internal.go
@@ -94,6 +94,14 @@ func (node *Node) Handle(msg api.Msg) (bool, error) {
 	}
 	clearMsg.Content = bytes.NewBuffer(clear)
 
+	if msg.Chunked {
+		err = api.HandleChunked(node, clearMsg)
+		if err != nil {
+			return false, err
+		}
+		return true, err
+	}
+
 	select {
 	case node.Out() <- clearMsg:
 		node.debugMsg("Sent message " + fmt.Sprint(msg.Content.Bytes()))

--- a/nodes/fs/internal.go
+++ b/nodes/fs/internal.go
@@ -141,6 +141,9 @@ func (node *Node) AddChunk(streamID uint32, chunkNum uint32, data []byte) error 
 	chunk.StreamID = streamID
 	chunk.ChunkNum = chunkNum
 	chunk.Data = data
+	if node.chunks[streamID] == nil {
+		node.chunks[streamID] = make(map[uint32]*api.Chunk)
+	}
 	node.chunks[streamID][chunkNum] = chunk
 	return nil
 }

--- a/nodes/fs/internal.go
+++ b/nodes/fs/internal.go
@@ -117,6 +117,26 @@ func (node *Node) signalMonitor() {
 	}()
 }
 
+// AddStream - adds a partial message header to internal storage
+func (node *Node) AddStream(streamID uint32, totalChunks uint32, channelName string) error {
+	stream := new(api.StreamHeader)
+	stream.StreamID = streamID
+	stream.NumChunks = totalChunks
+	stream.ChannelName = channelName
+	node.streams[streamID] = stream
+	return nil
+}
+
+// AddChunk - adds a chunk of a partial message to internal storage
+func (node *Node) AddChunk(streamID uint32, chunkNum uint32, data []byte) error {
+	chunk := new(api.Chunk)
+	chunk.StreamID = streamID
+	chunk.ChunkNum = chunkNum
+	chunk.Data = data
+	node.chunks[streamID][chunkNum] = chunk
+	return nil
+}
+
 /*
 	TODO:	encrypted debug and error messages?! yes please!
 			- you may want an application that can detect that messages have happend

--- a/nodes/fs/public.go
+++ b/nodes/fs/public.go
@@ -83,6 +83,7 @@ func (node *Node) Pickup(rpub bc.PubKey, lastTime int64, maxBytes int64, channel
 			if fileTime == retval.Time {
 				log.Println("Identical filetimes, attempting to exceed recommended protocol buffer size")
 			} else if bytesRead+int64(len(b)) >= maxBytes { // no room for next msg
+				log.Println("Result too big to be fetched on this transport! Flush and rechunk")
 				return io.EOF
 			}
 

--- a/nodes/qldb/admin.go
+++ b/nodes/qldb/admin.go
@@ -338,17 +338,8 @@ func (node *Node) Start() error {
 			if !more {
 				break
 			}
-
-			switch message.IsChan {
-			case true:
-				if err := node.SendChannel(message.Name, message.Content.Bytes(), message.PubKey); err != nil {
-					log.Fatal(err)
-				}
-
-			case false:
-				if err := node.Send(message.Name, message.Content.Bytes(), message.PubKey); err != nil {
-					log.Fatal(err)
-				}
+			if err := node.SendMsg(message); err != nil {
+				log.Fatal(err)
 			}
 		}
 	}()

--- a/nodes/qldb/admin.go
+++ b/nodes/qldb/admin.go
@@ -190,8 +190,8 @@ func (node *Node) SendMsg(msg api.Msg) error {
 	channelNameLen := uint32(0)
 	if msg.IsChan {
 		channelNameLen = uint32(len(msg.Name))
+		chunkSize -= (channelNameLen + 2) // +2 for channel length prefix
 	}
-	chunkSize -= (channelNameLen + 2) // +2 for channel length prefix
 
 	if msg.Content.Len() > 0 && uint32(msg.Content.Len()) > chunkSize { // we need to chunk
 		if msg.Chunked { // we're already chunked, freak out!

--- a/nodes/qldb/database.go
+++ b/nodes/qldb/database.go
@@ -627,7 +627,7 @@ func (node *Node) AddStream(streamID uint32, totalChunks uint32, channelName str
 func (node *Node) AddChunk(streamID uint32, chunkNum uint32, data []byte) error {
 	c := node.db()
 	defer closeDB(c)
-	sqlq := "SELECT chunks FROM chunks WHERE streamid==$1 AND chunknum==$2;"
+	sqlq := "SELECT chunknum FROM chunks WHERE streamid==$1 AND chunknum==$2;"
 	if sqlDebug {
 		log.Println(sqlq, streamID, chunkNum)
 	}
@@ -695,7 +695,7 @@ func (node *Node) qlGetChunkCount(streamID uint32) (uint64, error) {
 func (node *Node) qlGetChunks(streamID uint32) ([]api.Chunk, error) {
 	c := node.db()
 	defer closeDB(c)
-	sqlq := "SELECT streamid,chunknum,data FROM streams WHERE streamid==$1;"
+	sqlq := "SELECT streamid,chunknum,data FROM chunks WHERE streamid==$1 ORDER BY chunknum ASC;"
 	if sqlDebug {
 		log.Println(sqlq, streamID)
 	}

--- a/nodes/qldb/internal.go
+++ b/nodes/qldb/internal.go
@@ -18,34 +18,46 @@ func (node *Node) GetChannelPrivKey(name string) (string, error) {
 }
 
 // Forward - Add an already-encrypted message to the outbound message queue (forward it along)
-func (node *Node) Forward(channelName string, message []byte) error {
-	// prepend a uint16 of channel name length, little-endian
-	t := uint16(len(channelName))
-	rxsum := []byte{byte(t >> 8), byte(t & 0xFF)}
-	rxsum = append(rxsum, []byte(channelName)...)
-	message = append(rxsum, message...)
+func (node *Node) Forward(msg api.Msg) error {
 
-	return node.qlOutboxEnqueue(channelName, message, time.Now().UnixNano(), false) //true
+	flags := uint8(0)
+	if msg.IsChan {
+		flags |= api.ChannelFlag
+	}
+	if msg.Chunked {
+		flags |= api.ChunkedFlag
+	}
+	if msg.StreamHeader {
+		flags |= api.StreamHeaderFlag
+	}
+	rxsum := []byte{flags} // prepend flags byte
+	if msg.IsChan {
+		// prepend a uint16 of channel name length, little-endian
+		t := uint16(len(msg.Name))
+		rxsum = append(rxsum, byte(t>>8), byte(t&0xFF))
+		rxsum = append(rxsum, []byte(msg.Name)...)
+	}
+	message := append(rxsum, msg.Content.Bytes()...)
+	return node.qlOutboxEnqueue(msg.Name, message, time.Now().UnixNano(), false) //true
 }
 
 // Handle - Decrypt and handle an encrypted message
-func (node *Node) Handle(channelName string, message []byte) (bool, error) {
+func (node *Node) Handle(msg api.Msg) (bool, error) {
 	var clear []byte
 	var err error
 	var tagOK bool
 	var clearMsg api.Msg // msg to out channel
-	channelLen := len(channelName)
 
-	if channelLen > 0 {
-		v, ok := node.channelKeys[channelName]
+	if msg.IsChan {
+		v, ok := node.channelKeys[msg.Name]
 		if !ok {
 			return false, errors.New("Cannot Handle message for Unknown Channel")
 		}
-		clearMsg = api.Msg{Name: channelName, IsChan: true}
-		tagOK, clear, err = v.DecryptMessage(message)
+		clearMsg = api.Msg{Name: msg.Name, IsChan: true, Chunked: msg.Chunked, StreamHeader: msg.StreamHeader}
+		tagOK, clear, err = v.DecryptMessage(msg.Content.Bytes())
 	} else {
-		clearMsg = api.Msg{Name: "[content]", IsChan: false}
-		tagOK, clear, err = node.contentKey.DecryptMessage(message)
+		clearMsg = api.Msg{Name: "[content]", IsChan: false, Chunked: msg.Chunked, StreamHeader: msg.StreamHeader}
+		tagOK, clear, err = node.contentKey.DecryptMessage(msg.Content.Bytes())
 	}
 	// DecryptMessage will return !tagOK if the quick-check fails, which is common
 	if !tagOK || err != nil {
@@ -55,7 +67,7 @@ func (node *Node) Handle(channelName string, message []byte) (bool, error) {
 
 	select {
 	case node.Out() <- clearMsg:
-		node.debugMsg("Sent message " + fmt.Sprint(message))
+		node.debugMsg("Sent message " + fmt.Sprint(msg.Content.Bytes()))
 	default:
 		node.debugMsg("No message sent")
 	}

--- a/nodes/qldb/internal.go
+++ b/nodes/qldb/internal.go
@@ -65,6 +65,14 @@ func (node *Node) Handle(msg api.Msg) (bool, error) {
 	}
 	clearMsg.Content = bytes.NewBuffer(clear)
 
+	if msg.Chunked {
+		err = api.HandleChunked(node, clearMsg)
+		if err != nil {
+			return false, err
+		}
+		return true, err
+	}
+
 	select {
 	case node.Out() <- clearMsg:
 		node.debugMsg("Sent message " + fmt.Sprint(msg.Content.Bytes()))

--- a/nodes/ram/admin.go
+++ b/nodes/ram/admin.go
@@ -266,14 +266,7 @@ func (node *Node) SendChannel(channelName string, data []byte, pubkey ...bc.PubK
 func (node *Node) SendMsg(msg api.Msg) error {
 
 	// determine if we need to chunk
-	chunkSize := api.ChunkSize(node)
-	chunkSize -= (96 + 1) // todo: 96 is hardcoded overhead from assuming ECC but this needs an abstract method, +1 for flags
-	channelNameLen := uint32(0)
-	if msg.IsChan {
-		channelNameLen = uint32(len(msg.Name))
-		chunkSize -= (channelNameLen + 2) // +2 for channel length prefix
-	}
-
+	chunkSize := api.ChunkSize(node)                                    // finds the minimum transport byte limit
 	if msg.Content.Len() > 0 && uint32(msg.Content.Len()) > chunkSize { // we need to chunk
 		if msg.Chunked { // we're already chunked, freak out!
 			return errors.New("Chunked message needs to be chunked, bailing out")

--- a/nodes/ram/admin.go
+++ b/nodes/ram/admin.go
@@ -1,6 +1,7 @@
 package ram
 
 import (
+	"bytes"
 	"errors"
 	"log"
 	"time"
@@ -232,8 +233,7 @@ func (node *Node) Send(contactName string, data []byte, pubkey ...bc.PubKey) err
 			return err
 		}
 	}
-
-	return node.send("", destkey, data)
+	return node.SendMsg(api.Msg{Name: contactName, Content: bytes.NewBuffer(data), IsChan: false, PubKey: destkey, Chunked: false})
 }
 
 // SendChannelBulk : Transmit messages to a channel
@@ -259,27 +259,58 @@ func (node *Node) SendChannel(channelName string, data []byte, pubkey ...bc.PubK
 		}
 		destkey = c.Privkey.GetPubKey()
 	}
-
-	return node.send(channelName, destkey, data)
+	return node.SendMsg(api.Msg{Name: channelName, Content: bytes.NewBuffer(data), IsChan: true, PubKey: destkey, Chunked: false})
 }
 
-func (node *Node) send(channelName string, destkey bc.PubKey, msg []byte) error {
+// SendMsg : Transmits a message
+func (node *Node) SendMsg(msg api.Msg) error {
 
-	data, err := node.contentKey.EncryptMessage(msg, destkey)
+	// determine if we need to chunk
+	chunkSize := api.ChunkSize(node)
+	chunkSize -= (96 + 1) // todo: 96 is hardcoded overhead from assuming ECC but this needs an abstract method, +1 for flags
+	channelNameLen := uint32(0)
+	if msg.IsChan {
+		channelNameLen = uint32(len(msg.Name))
+	}
+	chunkSize -= (channelNameLen + 2) // +2 for channel length prefix
+
+	if msg.Content.Len() > 0 && uint32(msg.Content.Len()) > chunkSize { // we need to chunk
+		if msg.Chunked { // we're already chunked, freak out!
+			return errors.New("Chunked message needs to be chunked, bailing out")
+		}
+		return api.SendChunked(node, chunkSize, msg)
+	}
+
+	data, err := node.contentKey.EncryptMessage(msg.Content.Bytes(), msg.PubKey)
 	if err != nil {
 		return err
 	}
 
-	// prepend a uint16 of channel name length, little-endian
-	t := uint16(len(channelName))
-	rxsum := []byte{byte(t >> 8), byte(t & 0xFF)}
-	rxsum = append(rxsum, []byte(channelName)...)
-	data = append(rxsum, data...)
+	flags := uint8(0)
+	if msg.IsChan {
+		flags |= api.ChannelFlag
+	}
+	if msg.Chunked {
+		flags |= api.ChunkedFlag
+	}
+	if msg.StreamHeader {
+		flags |= api.StreamHeaderFlag
+	}
+	rxsum := []byte{flags} // prepend flags byte
 
+	if msg.IsChan {
+		// prepend a uint16 of channel name length, little-endian
+		t := uint16(len(msg.Name))
+		rxsum = append(rxsum, byte(t>>8), byte(t&0xFF))
+		rxsum = append(rxsum, []byte(msg.Name)...)
+	}
+	data = append(rxsum, data...)
 	ts := time.Now().UnixNano()
 
 	m := new(outboxMsg)
-	m.channel = channelName
+	if msg.IsChan {
+		m.channel = msg.Name
+	}
 	m.timeStamp = ts
 	m.msg = data
 	node.outbox.Append(m)

--- a/nodes/ram/admin.go
+++ b/nodes/ram/admin.go
@@ -369,7 +369,11 @@ func (node *Node) Start() error {
 			}
 			// for each stream, count chunks for that header
 			for _, stream := range node.streams {
-				count := len(node.chunks[stream.StreamID])
+				count := 0
+				if node.chunks[stream.StreamID] != nil {
+					count = len(node.chunks[stream.StreamID])
+				}
+
 				// if chunks == total chunks, re-assemble Msg and call Handle
 				if uint32(count) == uint32(stream.NumChunks) {
 					buf := bytes.NewBuffer([]byte{})

--- a/nodes/ram/admin.go
+++ b/nodes/ram/admin.go
@@ -357,15 +357,8 @@ func (node *Node) Start() error {
 			// read message off the input channel
 			message := <-node.In()
 			node.debugMsg("Message accepted on input channel")
-			switch message.IsChan {
-			case true:
-				if err := node.SendChannel(message.Name, message.Content.Bytes(), message.PubKey); err != nil {
-					log.Fatal("SendChannel failed in input loop")
-				}
-			case false:
-				if err := node.Send(message.Name, message.Content.Bytes(), message.PubKey); err != nil {
-					log.Fatal("Send failed in input loop")
-				}
+			if err := node.SendMsg(message); err != nil {
+				log.Fatal(err)
 			}
 		}
 	}()

--- a/nodes/ram/admin.go
+++ b/nodes/ram/admin.go
@@ -271,8 +271,8 @@ func (node *Node) SendMsg(msg api.Msg) error {
 	channelNameLen := uint32(0)
 	if msg.IsChan {
 		channelNameLen = uint32(len(msg.Name))
+		chunkSize -= (channelNameLen + 2) // +2 for channel length prefix
 	}
-	chunkSize -= (channelNameLen + 2) // +2 for channel length prefix
 
 	if msg.Content.Len() > 0 && uint32(msg.Content.Len()) > chunkSize { // we need to chunk
 		if msg.Chunked { // we're already chunked, freak out!

--- a/nodes/ram/admin.go
+++ b/nodes/ram/admin.go
@@ -3,6 +3,7 @@ package ram
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"log"
 	"time"
 
@@ -339,6 +340,8 @@ func (node *Node) Start() error {
 		}
 	}
 
+	node.isRunning = true
+
 	// input loop
 	go func() {
 		for {
@@ -356,7 +359,48 @@ func (node *Node) Start() error {
 		}
 	}()
 
-	node.isRunning = true
+	// dechunking loop
+	go func() {
+		for {
+			time.Sleep(10 * time.Millisecond)
+			// check if we should stop running
+			if !node.isRunning {
+				break
+			}
+			// for each stream, count chunks for that header
+			for _, stream := range node.streams {
+				count := len(node.chunks[stream.StreamID])
+				// if chunks == total chunks, re-assemble Msg and call Handle
+				if uint32(count) == uint32(stream.NumChunks) {
+					buf := bytes.NewBuffer([]byte{})
+					for i := uint32(0); i < stream.NumChunks; i++ {
+						chunk, ok := node.chunks[stream.StreamID][i]
+						if !ok {
+							log.Fatal("Chunk count miscalculated - code broken")
+						}
+						buf.Write(chunk.Data)
+					}
+
+					var msg api.Msg
+					if len(stream.ChannelName) > 0 {
+						msg.IsChan = true
+						msg.Name = stream.ChannelName
+					}
+					msg.Content = buf
+
+					select {
+					case node.Out() <- msg:
+						node.debugMsg("Sent message " + fmt.Sprint(msg.Content.Bytes()))
+						node.streams[stream.StreamID] = nil
+						node.chunks[stream.StreamID] = make(map[uint32]*api.Chunk)
+					default:
+						node.debugMsg("No message sent")
+					}
+				}
+			}
+		}
+	}()
+
 	return nil
 }
 

--- a/nodes/ram/internal.go
+++ b/nodes/ram/internal.go
@@ -129,6 +129,9 @@ func (node *Node) AddChunk(streamID uint32, chunkNum uint32, data []byte) error 
 	chunk.StreamID = streamID
 	chunk.ChunkNum = chunkNum
 	chunk.Data = data
+	if node.chunks[streamID] == nil {
+		node.chunks[streamID] = make(map[uint32]*api.Chunk)
+	}
 	node.chunks[streamID][chunkNum] = chunk
 	return nil
 }

--- a/nodes/ram/internal.go
+++ b/nodes/ram/internal.go
@@ -105,6 +105,26 @@ func (node *Node) signalMonitor() {
 	}()
 }
 
+// AddStream - adds a partial message header to internal storage
+func (node *Node) AddStream(streamID uint32, totalChunks uint32, channelName string) error {
+	stream := new(api.StreamHeader)
+	stream.StreamID = streamID
+	stream.NumChunks = totalChunks
+	stream.ChannelName = channelName
+	node.streams[streamID] = stream
+	return nil
+}
+
+// AddChunk - adds a chunk of a partial message to internal storage
+func (node *Node) AddChunk(streamID uint32, chunkNum uint32, data []byte) error {
+	chunk := new(api.Chunk)
+	chunk.StreamID = streamID
+	chunk.ChunkNum = chunkNum
+	chunk.Data = data
+	node.chunks[streamID][chunkNum] = chunk
+	return nil
+}
+
 /*
 	TODO:	encrypted debug and error messages?! yes please!
 			- you may want an application that can detect that messages have happend

--- a/nodes/ram/internal.go
+++ b/nodes/ram/internal.go
@@ -82,6 +82,14 @@ func (node *Node) Handle(msg api.Msg) (bool, error) {
 
 	clearMsg.Content = bytes.NewBuffer(clear)
 
+	if msg.Chunked {
+		err = api.HandleChunked(node, clearMsg)
+		if err != nil {
+			return false, err
+		}
+		return true, err
+	}
+
 	select {
 	case node.Out() <- clearMsg:
 		node.debugMsg("Sent message " + fmt.Sprint(msg.Content.Bytes()))

--- a/nodes/ram/internal.go
+++ b/nodes/ram/internal.go
@@ -22,19 +22,34 @@ func (node *Node) GetChannelPrivKey(name string) (string, error) {
 }
 
 // Forward - Add an already-encrypted message to the outbound message queue (forward it along)
-func (node *Node) Forward(channelName string, message []byte) error {
-	// prepend a uint16 of channel name length, little-endian
-	t := uint16(len(channelName))
-	rxsum := []byte{byte(t >> 8), byte(t & 0xFF)}
-	rxsum = append(rxsum, []byte(channelName)...)
-	message = append(rxsum, message...)
+func (node *Node) Forward(msg api.Msg) error {
 
+	flags := uint8(0)
+	if msg.IsChan {
+		flags |= api.ChannelFlag
+	}
+	if msg.Chunked {
+		flags |= api.ChunkedFlag
+	}
+	if msg.StreamHeader {
+		flags |= api.StreamHeaderFlag
+	}
+	rxsum := []byte{flags} // prepend flags byte
+	m := new(outboxMsg)
+	if msg.IsChan {
+		// prepend a uint16 of channel name length, little-endian
+		t := uint16(len(msg.Name))
+		rxsum = append(rxsum, byte(t>>8), byte(t&0xFF))
+		rxsum = append(rxsum, []byte(msg.Name)...)
+		m.channel = msg.Name
+	}
+	message := append(rxsum, msg.Content.Bytes()...)
+
+	/* todo: commented out, this is not what other nodes do
 	if node.outbox.MsgExists(channelName, message) {
 		return nil
 	}
-
-	m := new(outboxMsg)
-	m.channel = channelName
+	*/
 	m.timeStamp = time.Now().UnixNano()
 	m.msg = message
 	node.outbox.Append(m)
@@ -43,23 +58,22 @@ func (node *Node) Forward(channelName string, message []byte) error {
 
 // Handle - Decrypt and handle an encrypted message
 // 			returns TagOK, which is true if the message is intended for a key we have
-func (node *Node) Handle(channelName string, message []byte) (bool, error) {
+func (node *Node) Handle(msg api.Msg) (bool, error) {
 	var clear []byte
 	var err error
 	tagOK := false
 	var clearMsg api.Msg // msg to out channel
-	channelLen := len(channelName)
 
-	if channelLen > 0 {
-		v, ok := node.channels[channelName]
+	if msg.IsChan {
+		v, ok := node.channels[msg.Name]
 		if !ok || v.Privkey == nil {
 			return tagOK, errors.New("Cannot Handle message for Unknown Channel")
 		}
-		clearMsg = api.Msg{Name: channelName, IsChan: true}
-		tagOK, clear, err = v.Privkey.DecryptMessage(message)
+		clearMsg = api.Msg{Name: msg.Name, IsChan: true, Chunked: msg.Chunked, StreamHeader: msg.StreamHeader}
+		tagOK, clear, err = v.Privkey.DecryptMessage(msg.Content.Bytes())
 	} else {
-		clearMsg = api.Msg{Name: "[content]", IsChan: false}
-		tagOK, clear, err = node.contentKey.DecryptMessage(message)
+		clearMsg = api.Msg{Name: "[content]", IsChan: false, Chunked: msg.Chunked, StreamHeader: msg.StreamHeader}
+		tagOK, clear, err = node.contentKey.DecryptMessage(msg.Content.Bytes())
 	}
 	// DecryptMessage will return !tagOK if the quick-check fails, which is common
 	if !tagOK || err != nil {
@@ -70,7 +84,7 @@ func (node *Node) Handle(channelName string, message []byte) (bool, error) {
 
 	select {
 	case node.Out() <- clearMsg:
-		node.debugMsg("Sent message " + fmt.Sprint(message))
+		node.debugMsg("Sent message " + fmt.Sprint(msg.Content.Bytes()))
 	default:
 		node.debugMsg("No message sent")
 	}

--- a/nodes/ram/outbox.go
+++ b/nodes/ram/outbox.go
@@ -81,7 +81,7 @@ func (o *outboxQueue) MsgsSince(lastTime int64, maxBytes int64, channelNames ...
 
 				if maxBytes > 0 && int64(proposedSize) > maxBytes {
 					if msgsSize == 0 {
-						log.Fatal("Bailing with zero return results!", proposedSize, len(mail.msg), msgsSize, maxBytes)
+						log.Fatal("Result too big to be fetched on this transport! Flush and rechunk")
 					}
 					break
 				}

--- a/nodes/ram/ramnode.go
+++ b/nodes/ram/ramnode.go
@@ -33,6 +33,8 @@ type Node struct {
 	outbox   outboxQueue
 	peers    map[string]*api.Peer
 	profiles map[string]*api.ProfilePriv
+	streams  map[uint32]*api.StreamHeader
+	chunks   map[uint32]map[uint32]*api.Chunk
 }
 
 // New : creates a new instance of API
@@ -46,6 +48,9 @@ func New(contentKey, routingKey bc.KeyPair) *Node {
 	node.contacts = make(map[string]*api.Contact)
 	node.peers = make(map[string]*api.Peer)
 	node.profiles = make(map[string]*api.ProfilePriv)
+
+	node.streams = make(map[uint32]*api.StreamHeader)
+	node.chunks = make(map[uint32]map[uint32]*api.Chunk)
 
 	// set crypto modes
 	if contentKey == nil {

--- a/nodes/ram/ramnode.go
+++ b/nodes/ram/ramnode.go
@@ -48,7 +48,6 @@ func New(contentKey, routingKey bc.KeyPair) *Node {
 	node.contacts = make(map[string]*api.Contact)
 	node.peers = make(map[string]*api.Peer)
 	node.profiles = make(map[string]*api.ProfilePriv)
-
 	node.streams = make(map[uint32]*api.StreamHeader)
 	node.chunks = make(map[uint32]map[uint32]*api.Chunk)
 

--- a/policy/p2p.go
+++ b/policy/p2p.go
@@ -241,7 +241,9 @@ func (s *P2P) mdnsListen() error {
 					for s.IsListening {
 						//st := time.Now()
 						if happy, err := PollServer(trans, s.Node, target[len(u.Scheme)+3:], pubsrv); !happy {
-							log.Println(err.Error())
+							if err != nil {
+								log.Println(err.Error())
+							}
 						}
 						//st2 := time.Now()
 						//log.Printf("p2p PollServer took: %s\n", st2.Sub(st).String())

--- a/ratnet/main_test.go
+++ b/ratnet/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"log"
+	"net"
 	"os"
 	"strconv"
 	"testing"
@@ -51,7 +52,7 @@ var transportType int
 
 func init() {
 	nodeType = DB
-	transportType = UDP
+	transportType = TLS
 }
 
 var (
@@ -61,11 +62,26 @@ var (
 
 	p2p1 TestNode
 	p2p2 TestNode
+	p2p3 TestNode
+	p2p4 TestNode
 
 	server6 TestNode
 	server7 TestNode
 	server8 TestNode
 )
+
+// Get preferred outbound ip of this machine
+func GetOutboundIP() net.IP {
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+
+	return localAddr.IP
+}
 
 func initNode(n int64, testNode TestNode, nodeType int, transportType int, p2pMode bool) TestNode {
 	num := strconv.FormatInt(n, 10)
@@ -112,7 +128,8 @@ func initNode(n int64, testNode TestNode, nodeType int, transportType int, p2pMo
 			testNode.Admin = https.New("tmp/cert"+num+".pem", "tmp/key"+num+".pem", testNode.Node, true)
 		}
 		if p2pMode {
-			go p2p(testNode.Public, testNode.Admin, testNode.Node, "localhost:3000"+num, "localhost:30"+num+"0"+num)
+			ip := GetOutboundIP().String()
+			go p2p(testNode.Public, testNode.Admin, testNode.Node, ip+":3000"+num, ip+":30"+num+"0"+num)
 		} else {
 			go serve(testNode.Public, testNode.Admin, testNode.Node, "localhost:3000"+num, "localhost:30"+num+"0"+num)
 		}
@@ -495,34 +512,6 @@ func Test_server_SendChannel_1(t *testing.T) {
 	}
 }
 
-var randmessage []byte
-
-func Test_server_SendChannel_2(t *testing.T) { // now with chunking
-	server1 = initNode(1, server1, nodeType, transportType, false)
-
-	randmessage, err := bc.GenerateRandomBytes(8675)
-	if err != nil {
-		t.Error(err.Error())
-	}
-	//override byte limit to trigger chunking
-	oldByteLimit := server1.Public.ByteLimit()
-	server1.Public.SetByteLimit(4096)
-
-	// should not work on public interface
-	_, err = server1.Public.RPC("localhost:30001", "SendChannel", "channel1", []byte(randmessage))
-	if err == nil {
-		t.Error(errors.New("SendChannel was accessible on Public network interface"))
-	}
-
-	_, err = server1.Admin.RPC("localhost:30101", "SendChannel", "channel1", []byte(randmessage))
-	if err != nil {
-		t.Error(err.Error())
-	}
-
-	//restore byte limit
-	server1.Public.SetByteLimit(oldByteLimit)
-}
-
 func Test_server_PickupDropoff_1(t *testing.T) {
 	server1 = initNode(1, server1, nodeType, transportType, false)
 	server2 = initNode(2, server2, nodeType, transportType, false)
@@ -592,11 +581,12 @@ func Test_server_PickupDropoff_2(t *testing.T) {
 	}
 }
 
+var randmessage []byte
+
 func Test_p2p_Basic_1(t *testing.T) {
 
 	p2p1 = initNode(4, p2p1, nodeType, transportType, true)
 	p2p2 = initNode(5, p2p2, nodeType, transportType, true)
-
 	for p2p1.Node == nil || p2p2.Node == nil {
 		time.Sleep(1 * time.Second)
 	}
@@ -613,10 +603,45 @@ func Test_p2p_Basic_1(t *testing.T) {
 	if err := p2p2.Node.AddChannel("test1", pubprivkeyb64Ecc); err != nil {
 		t.Error(err.Error())
 	}
-
 	if err := p2p1.Node.SendChannel("test1", []byte(testMessage1)); err != nil {
 		t.Error(err.Error())
 	}
+}
+
+func Test_p2p_Chunking_1(t *testing.T) {
+
+	p2p3 = initNode(6, p2p3, nodeType, transportType, true)
+	p2p4 = initNode(7, p2p4, nodeType, transportType, true)
+	for p2p3.Node == nil || p2p4.Node == nil {
+		time.Sleep(1 * time.Second)
+	}
+
+	go func() {
+		msg := <-p2p4.Node.Out()
+		t.Log("p2p4.Out Got: ")
+		t.Log(msg)
+	}()
+
+	if err := p2p3.Node.AddChannel("test1", pubprivkeyb64Ecc); err != nil {
+		t.Error(err.Error())
+	}
+	if err := p2p4.Node.AddChannel("test1", pubprivkeyb64Ecc); err != nil {
+		t.Error(err.Error())
+	}
+	randmessage, err := bc.GenerateRandomBytes(8675)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	//override byte limit to trigger chunking
+	oldByteLimit := p2p3.Public.ByteLimit()
+	p2p3.Public.SetByteLimit(4096)
+	if err := p2p3.Node.SendChannel("test1", randmessage); err != nil {
+		t.Error(err.Error())
+	}
+
+	time.Sleep(30 * time.Second)
+	p2p3.Public.SetByteLimit(oldByteLimit)
+
 }
 
 // Test Messages

--- a/ratnet/main_test.go
+++ b/ratnet/main_test.go
@@ -495,6 +495,34 @@ func Test_server_SendChannel_1(t *testing.T) {
 	}
 }
 
+var randmessage []byte
+
+func Test_server_SendChannel_2(t *testing.T) { // now with chunking
+	server1 = initNode(1, server1, nodeType, transportType, false)
+
+	randmessage, err := bc.GenerateRandomBytes(8675)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	//override byte limit to trigger chunking
+	oldByteLimit := server1.Public.ByteLimit()
+	server1.Public.SetByteLimit(4096)
+
+	// should not work on public interface
+	_, err = server1.Public.RPC("localhost:30001", "SendChannel", "channel1", []byte(randmessage))
+	if err == nil {
+		t.Error(errors.New("SendChannel was accessible on Public network interface"))
+	}
+
+	_, err = server1.Admin.RPC("localhost:30101", "SendChannel", "channel1", []byte(randmessage))
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	//restore byte limit
+	server1.Public.SetByteLimit(oldByteLimit)
+}
+
 func Test_server_PickupDropoff_1(t *testing.T) {
 	server1 = initNode(1, server1, nodeType, transportType, false)
 	server2 = initNode(2, server2, nodeType, transportType, false)

--- a/ratnet/main_test.go
+++ b/ratnet/main_test.go
@@ -616,10 +616,13 @@ func Test_p2p_Chunking_1(t *testing.T) {
 		time.Sleep(1 * time.Second)
 	}
 
+	done := make(chan bool)
+
 	go func() {
 		msg := <-p2p4.Node.Out()
 		t.Log("p2p4.Out Got: ")
 		t.Log(msg)
+		done <- true
 	}()
 
 	if err := p2p3.Node.AddChannel("test1", pubprivkeyb64Ecc); err != nil {
@@ -639,7 +642,8 @@ func Test_p2p_Chunking_1(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	time.Sleep(30 * time.Second)
+	_ = <-done
+
 	p2p3.Public.SetByteLimit(oldByteLimit)
 
 }

--- a/ratnet/main_test.go
+++ b/ratnet/main_test.go
@@ -616,13 +616,13 @@ func Test_p2p_Chunking_1(t *testing.T) {
 		time.Sleep(1 * time.Second)
 	}
 
-	done := make(chan bool)
+	done := make(chan []byte)
 
 	go func() {
 		msg := <-p2p4.Node.Out()
-		t.Log("p2p4.Out Got: ")
-		t.Log(msg)
-		done <- true
+		t.Log("p2p4.Out Returned Data!")
+		//t.Log(msg)
+		done <- msg.Content.Bytes()
 	}()
 
 	if err := p2p3.Node.AddChannel("test1", pubprivkeyb64Ecc); err != nil {
@@ -642,10 +642,14 @@ func Test_p2p_Chunking_1(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	_ = <-done
-
+	gotbytes := <-done
 	p2p3.Public.SetByteLimit(oldByteLimit)
 
+	if bytes.Compare(gotbytes, randmessage) == 0 {
+		t.Log("PASS:  Byte arrays were an exact match!!!")
+	} else {
+		t.Error("Byte arrays did not match")
+	}
 }
 
 // Test Messages

--- a/router/default.go
+++ b/router/default.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"log"
 
 	"github.com/awgh/ratnet"
 	"github.com/awgh/ratnet/api"
@@ -118,11 +119,19 @@ func (r *DefaultRouter) Route(node api.Node, message []byte) error {
 	var channelLen uint16 // beginning uint16 of message is channel name length
 	if msg.IsChan {
 		channelLen = (uint16(message[1]) << 8) | uint16(message[2])
-		if len(message) < int(channelLen)+1+2+64 { // flags + uint16 + LuggageTag
-			return errors.New("Incorrect channel name length")
-		}
+		/*
+			if len(message) < int(channelLen)+1+2+56 { //+64 { // flags + uint16 + LuggageTag
+
+				log.Println(message)
+				return errors.New("Incorrect channel name length")
+			}
+		*/
 		msg.Name = string(message[3 : 3+channelLen]) // flags[0], chan name length[1,2]
 		idx += 2 + int(channelLen)                   //skip over the channel name
+	}
+	if idx+16 >= len(message) {
+		log.Println(message)
+		return errors.New("Malformed message")
 	}
 	nonce := message[idx : idx+16] // todo: this is truncating half the pubkey
 	if r.seenRecently(nonce) {     // LOOP PREVENTION before handling or forwarding

--- a/router/default.go
+++ b/router/default.go
@@ -117,8 +117,8 @@ func (r *DefaultRouter) Route(node api.Node, message []byte) error {
 	msg.StreamHeader = ((flags & api.StreamHeaderFlag) != 0)
 	var channelLen uint16 // beginning uint16 of message is channel name length
 	if msg.IsChan {
-		channelLen = (uint16(message[0]) << 8) | uint16(message[1])
-		if len(message) < int(channelLen)+2+64 { // uint16 + LuggageTag
+		channelLen = (uint16(message[1]) << 8) | uint16(message[2])
+		if len(message) < int(channelLen)+1+2+64 { // flags + uint16 + LuggageTag
 			return errors.New("Incorrect channel name length")
 		}
 		msg.Name = string(message[3 : 3+channelLen]) // flags[0], chan name length[1,2]

--- a/router/default.go
+++ b/router/default.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 
@@ -80,19 +81,24 @@ func (r *DefaultRouter) GetPatches() []api.Patch {
 	return r.Patches
 }
 
-// forward - channel prefixes have been stripped from message when they get here
-func (r *DefaultRouter) forward(node api.Node, channelName string, message []byte) error {
+func (r *DefaultRouter) forward(node api.Node, msg api.Msg) error {
 	for _, p := range r.Patches { //todo: this could be constant-time
-		if channelName == p.From {
+		if msg.Name == p.From { // we don't check for IsChan here, we allow forwarding from "" chan to channels
 			for i := 0; i < len(p.To); i++ {
-				if err := node.Forward(p.To[i], message); err != nil {
+				msg.Name = p.To[i]
+				if msg.Name == "" {
+					msg.IsChan = false
+				} else {
+					msg.IsChan = true
+				}
+				if err := node.Forward(msg); err != nil {
 					return err
 				}
 			}
 			return nil
 		}
 	}
-	if err := node.Forward(channelName, message); err != nil {
+	if err := node.Forward(msg); err != nil {
 		return err
 	}
 	return nil
@@ -103,41 +109,47 @@ func (r *DefaultRouter) Route(node api.Node, message []byte) error {
 
 	//  Stuff Everything will need just about every time...
 	//
+	var msg api.Msg
+	flags := message[0]
+	idx := 1
+	msg.IsChan = ((flags & api.ChannelFlag) != 0)
+	msg.Chunked = ((flags & api.ChunkedFlag) != 0)
+	msg.StreamHeader = ((flags & api.StreamHeaderFlag) != 0)
 	var channelLen uint16 // beginning uint16 of message is channel name length
-	channelName := ""
-	channelLen = (uint16(message[0]) << 8) | uint16(message[1])
-	if len(message) < int(channelLen)+2+64 { // uint16 + LuggageTag
-		return errors.New("Incorrect channel name length")
+	if msg.IsChan {
+		channelLen = (uint16(message[0]) << 8) | uint16(message[1])
+		if len(message) < int(channelLen)+2+64 { // uint16 + LuggageTag
+			return errors.New("Incorrect channel name length")
+		}
+		msg.Name = string(message[3 : 3+channelLen]) // flags[0], chan name length[1,2]
+		idx += 2 + int(channelLen)                   //skip over the channel name
 	}
-	idx := 2 + channelLen          //skip over the channel name
 	nonce := message[idx : idx+16] // todo: this is truncating half the pubkey
 	if r.seenRecently(nonce) {     // LOOP PREVENTION before handling or forwarding
 		return nil
 	}
-
 	cid, err := node.CID() // we need this for cloning
 	if err != nil {
 		return err
 	}
-	//
+	msg.Content = bytes.NewBuffer(message[idx:])
 
-	// When the channel tag is set...
-	if channelLen > 0 { // channel message
-		channelName = string(message[2 : 2+channelLen])
+	// Routing Logic
+	if msg.IsChan { // channel message
 		consumed := false
 		if r.CheckChannels {
-			chn, err := node.GetChannel(channelName)
+			chn, err := node.GetChannel(msg.Name)
 			if chn != nil && err == nil { // this is a channel key we know
 				pubkey := cid.Clone()
 				pubkey.FromB64(chn.Pubkey)
-				consumed, err = node.Handle(channelName, message[idx:])
+				consumed, err = node.Handle(msg)
 				if err != nil {
 					return err
 				}
 			}
 		}
 		if (!consumed && r.ForwardUnknownChannels) || (consumed && r.ForwardConsumedChannels) {
-			if err := r.forward(node, channelName, message[idx:]); err != nil {
+			if err := r.forward(node, msg); err != nil {
 				return err
 			}
 		}
@@ -145,13 +157,13 @@ func (r *DefaultRouter) Route(node api.Node, message []byte) error {
 		// content key case (to be removed, deprecated)
 		consumed := false
 		if r.CheckContent {
-			consumed, err = node.Handle(channelName, message[idx:])
+			consumed, err = node.Handle(msg)
 			if err != nil {
 				return err
 			}
 		}
 		if (!consumed && r.ForwardUnknownContent) || (consumed && r.ForwardConsumedContent) {
-			if err := r.forward(node, channelName, message[idx:]); err != nil {
+			if err := r.forward(node, msg); err != nil {
 				return err
 			}
 		}
@@ -169,7 +181,7 @@ func (r *DefaultRouter) Route(node api.Node, message []byte) error {
 				}
 				pubkey := cid.Clone()
 				pubkey.FromB64(profile.Pubkey)
-				consumed, err = node.Handle(channelName, message[idx:])
+				consumed, err = node.Handle(msg)
 				if err != nil {
 					return err
 				}
@@ -179,7 +191,7 @@ func (r *DefaultRouter) Route(node api.Node, message []byte) error {
 			}
 		}
 		if (!consumed && r.ForwardUnknownProfiles) || (consumed && r.ForwardConsumedProfiles) {
-			if err := r.forward(node, channelName, message[idx:]); err != nil {
+			if err := r.forward(node, msg); err != nil {
 				return err
 			}
 		}

--- a/transports/udp/udp.go
+++ b/transports/udp/udp.go
@@ -93,7 +93,7 @@ func (m *Module) Listen(listen string, adminMode bool) {
 				continue
 			}
 
-			//log.Println("UDP accepted new connection")
+			log.Println("UDP accepted new connection")
 
 			c.SetReadDeadline(time.Now().Add(35 * time.Second))
 			c.SetWriteDeadline(time.Now().Add(35 * time.Second))

--- a/transports/udp/udp.go
+++ b/transports/udp/udp.go
@@ -106,7 +106,7 @@ func (m *Module) Listen(listen string, adminMode bool) {
 
 					// read
 					blen := make([]byte, 4)
-					n, err := reader.Read(blen)
+					n, err := io.ReadFull(reader, blen)
 					if n != 4 {
 						log.Println("Listen remote read len underflow: n =", n)
 						break
@@ -117,7 +117,7 @@ func (m *Module) Listen(listen string, adminMode bool) {
 					}
 					rlen := binary.LittleEndian.Uint32(blen)
 					buf := make([]byte, rlen)
-					n, err = reader.Read(buf)
+					n, err = io.ReadFull(reader, buf)
 					if uint32(n) != rlen {
 						log.Println("Listen remote read underflow: n =", n)
 						break
@@ -214,7 +214,7 @@ func (m *Module) RPC(host string, method string, args ...interface{}) (interface
 
 	// read
 	blen := make([]byte, 4)
-	n, err := reader.Read(blen)
+	n, err := io.ReadFull(reader, blen)
 	if n != 4 {
 		log.Println("RPC remote read len underflow: n =", n)
 		delete(cachedSessions, host) // something's wrong, make a new session next attempt
@@ -229,7 +229,7 @@ func (m *Module) RPC(host string, method string, args ...interface{}) (interface
 	}
 	wlen := binary.LittleEndian.Uint32(blen)
 	buf := make([]byte, wlen)
-	n, err = reader.Read(buf)
+	n, err = io.ReadFull(reader, buf)
 	if uint32(n) != wlen {
 		log.Println("RPC remote read underflow: n =", n)
 		delete(cachedSessions, host) // something's wrong, make a new session next attempt


### PR DESCRIPTION
This is a BREAKING API CHANGE. Adds automatic chunking and de-chunking to the core API.

Most application code will not have to change, but custom nodes might have to make small adjustments to API calls.  Apps have the option of using the new SendMsg call, which is more efficient than the Send/SendChannel calls, which are eventually going to be deprecated.

This merge also breaks the wire format a little bit, but it will save a whole byte on every non-channel message.

