### PR TITLE
In mem certs

### DIFF
--- a/ratnet/main.go
+++ b/ratnet/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/awgh/bencrypt/bc"
 	"github.com/awgh/bencrypt/ecc"
 	"github.com/awgh/ratnet/api"
 	"github.com/awgh/ratnet/nodes/qldb"
@@ -57,5 +58,10 @@ func main() {
 	// RamNode Mode:
 	//node := ram.New(new(ecc.KeyPair), new(ecc.KeyPair))
 
-	serve(https.New("cert.pem", "key.pem", node, true), https.New("cert.pem", "key.pem", node, true), node, publicString, adminString)
+	cert, key, err := bc.GenerateSSLCertBytes(true)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	serve(https.New(cert, key, node, true), https.New(cert, key, node, true), node, publicString, adminString)
 }

--- a/ratnet/main_test.go
+++ b/ratnet/main_test.go
@@ -105,11 +105,21 @@ func initNode(n int64, testNode TestNode, nodeType int, transportType int, p2pMo
 			testNode.Public = udp.New(testNode.Node)
 			testNode.Admin = udp.New(testNode.Node)
 		} else if transportType == TLS {
-			testNode.Public = tls.New("tmp/cert"+num+".pem", "tmp/key"+num+".pem", testNode.Node, true)
-			testNode.Admin = tls.New("tmp/cert"+num+".pem", "tmp/key"+num+".pem", testNode.Node, true)
+			cert, key, err := bc.GenerateSSLCertBytes(true)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			testNode.Public = tls.New(cert, key, testNode.Node, true)
+			testNode.Admin = tls.New(cert, key, testNode.Node, true)
 		} else {
-			testNode.Public = https.New("tmp/cert"+num+".pem", "tmp/key"+num+".pem", testNode.Node, true)
-			testNode.Admin = https.New("tmp/cert"+num+".pem", "tmp/key"+num+".pem", testNode.Node, true)
+			cert, key, err := bc.GenerateSSLCertBytes(true)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			testNode.Public = https.New(cert, key, testNode.Node, true)
+			testNode.Admin = https.New(cert, key, testNode.Node, true)
 		}
 		if p2pMode {
 			go p2p(testNode.Public, testNode.Admin, testNode.Node, "localhost:3000"+num, "localhost:30"+num+"0"+num)

--- a/transports/https/https.go
+++ b/transports/https/https.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/awgh/bencrypt/bc"
 	"github.com/awgh/ratnet"
 	"github.com/awgh/ratnet/api"
 )
@@ -23,29 +22,28 @@ func init() {
 
 // NewFromMap : Makes a new instance of this transport module from a map of arguments (for deserialization support)
 func NewFromMap(node api.Node, t map[string]interface{}) api.Transport {
-	certfile := "cert.pem"
-	keyfile := "key.pem"
+	var certBytes, keyBytes []byte //, _ := bc.GenerateSSLCertBytes()
 	eccMode := true
 
-	if _, ok := t["Certfile"]; ok {
-		certfile = t["Certfile"].(string)
+	if _, ok := t["Cert"]; ok {
+		certBytes = t["Cert"].([]byte)
 	}
-	if _, ok := t["KeyFile"]; ok {
-		keyfile = t["KeyFile"].(string)
+	if _, ok := t["Key"]; ok {
+		keyBytes = t["Key"].([]byte)
 	}
 	if _, ok := t["EccMode"]; ok {
 		eccMode = t["EccMode"].(bool)
 	}
-	return New(certfile, keyfile, node, eccMode)
+	return New(certBytes, keyBytes, node, eccMode)
 }
 
 // New : Makes a new instance of this transport module
-func New(certfile string, keyfile string, node api.Node, eccMode bool) *Module {
+func New(cert []byte, key []byte, node api.Node, eccMode bool) *Module {
 
 	web := new(Module)
 
-	web.Certfile = certfile
-	web.Keyfile = keyfile
+	web.Cert = cert
+	web.Key = key
 	web.node = node
 	web.EccMode = eccMode
 
@@ -70,8 +68,8 @@ type Module struct {
 	wg        sync.WaitGroup
 	listeners []net.Listener
 
-	Certfile, Keyfile string
-	EccMode           bool
+	Cert, Key []byte
+	EccMode   bool
 
 	byteLimit int64
 }
@@ -85,8 +83,8 @@ func (*Module) Name() string {
 func (h *Module) MarshalJSON() (b []byte, e error) {
 	return json.Marshal(map[string]interface{}{
 		"Transport": "https",
-		"Certfile":  h.Certfile,
-		"Keyfile":   h.Keyfile,
+		"Certfile":  h.Cert,
+		"Keyfile":   h.Key,
 		"EccMode":   h.EccMode})
 }
 
@@ -105,8 +103,7 @@ func (h *Module) Listen(listen string, adminMode bool) {
 	}
 
 	// init ssl components
-	bc.InitSSL(h.Certfile, h.Keyfile, h.EccMode)
-	cert, err := tls.LoadX509KeyPair(h.Certfile, h.Keyfile)
+	cert, err := tls.X509KeyPair(h.Cert, h.Key)
 	if err != nil {
 		log.Println(err.Error())
 		return
@@ -162,7 +159,6 @@ func (h *Module) handleResponse(w http.ResponseWriter, r *http.Request, node api
 	} else {
 		result, err = node.PublicRPC(h, a)
 	}
-	//log.Printf("result type %T \n", result)
 
 	rr := api.RemoteResponse{}
 	if err != nil {
@@ -193,7 +189,6 @@ func (h *Module) RPC(host string, method string, args ...interface{}) (interface
 	}
 
 	req, _ := http.NewRequest("POST", "https://"+host, &buf)
-	//req.Header.Add("Accept", "application/json")
 
 	resp, err := h.client.Do(req)
 	if err != nil {
@@ -207,8 +202,6 @@ func (h *Module) RPC(host string, method string, args ...interface{}) (interface
 		log.Println("https rpc gob decode failed: " + err.Error())
 		return nil, err
 	}
-
-	//log.Printf("https dirty rx in rpc: %+v\n", rr.Value)
 
 	if rr.IsErr() {
 		return nil, errors.New(rr.Error)

--- a/transports/tls/tls.go
+++ b/transports/tls/tls.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"sync"
 
-	"github.com/awgh/bencrypt/bc"
 	"github.com/awgh/ratnet"
 	"github.com/awgh/ratnet/api"
 )
@@ -25,29 +24,28 @@ func init() {
 
 // NewFromMap : Makes a new instance of this transport module from a map of arguments (for deserialization support)
 func NewFromMap(node api.Node, t map[string]interface{}) api.Transport {
-	certfile := "cert.pem"
-	keyfile := "key.pem"
+	var certBytes, keyBytes []byte //, _ := bc.GenerateSSLCertBytes()
 	eccMode := true
 
-	if _, ok := t["Certfile"]; ok {
-		certfile = t["Certfile"].(string)
+	if _, ok := t["Cert"]; ok {
+		certBytes = t["Cert"].([]byte)
 	}
-	if _, ok := t["KeyFile"]; ok {
-		keyfile = t["KeyFile"].(string)
+	if _, ok := t["Key"]; ok {
+		keyBytes = t["Key"].([]byte)
 	}
 	if _, ok := t["EccMode"]; ok {
 		eccMode = t["EccMode"].(bool)
 	}
-	return New(certfile, keyfile, node, eccMode)
+	return New(certBytes, keyBytes, node, eccMode)
 }
 
 // New : Makes a new instance of this transport module
-func New(certfile string, keyfile string, node api.Node, eccMode bool) *Module {
+func New(cert, key []byte, node api.Node, eccMode bool) *Module {
 
 	tls := new(Module)
 
-	tls.Certfile = certfile
-	tls.Keyfile = keyfile
+	tls.Cert = cert
+	tls.Key = key
 	tls.node = node
 	tls.EccMode = eccMode
 
@@ -63,8 +61,8 @@ type Module struct {
 	wg        sync.WaitGroup
 	listeners []net.Listener
 
-	Certfile, Keyfile string
-	EccMode           bool
+	Cert, Key []byte
+	EccMode   bool
 
 	byteLimit int64
 }
@@ -78,8 +76,8 @@ func (*Module) Name() string {
 func (h *Module) MarshalJSON() (b []byte, e error) {
 	return json.Marshal(map[string]interface{}{
 		"Transport": "tls",
-		"Certfile":  h.Certfile,
-		"Keyfile":   h.Keyfile,
+		"Cert":      h.Cert,
+		"Key":       h.Key,
 		"EccMode":   h.EccMode})
 }
 
@@ -100,8 +98,7 @@ func (h *Module) Listen(listen string, adminMode bool) {
 	}
 
 	// init ssl components
-	bc.InitSSL(h.Certfile, h.Keyfile, h.EccMode)
-	cert, err := tls.LoadX509KeyPair(h.Certfile, h.Keyfile)
+	cert, err := tls.X509KeyPair(h.Cert, h.Key)
 	if err != nil {
 		log.Println(err.Error())
 		return


### PR DESCRIPTION
This changes the signature and internal structure of the TLS and HTTPS transports so that they are instantiated with TLS certificate and key bytes, instead of filenames. This allows for more flexibility, as the caller can either choose to generate a cert and key in memory and pass the bytes in when creating a TLS or HTTPS transport, or they can get the cert & key bytes from a file on disk.