### PR TITLE
Fix rapid sending/receiving of messages

### DIFF
--- a/nodes/db/dbnode.go
+++ b/nodes/db/dbnode.go
@@ -14,6 +14,8 @@ import (
 	"upper.io/db.v3/lib/sqlbuilder"
 )
 
+var OutBufferSize = 128
+
 // Node : defines an instance of the API with a ql-DB backed Node
 type Node struct {
 	contentKey  bc.KeyPair
@@ -52,7 +54,7 @@ func New(contentKey, routingKey bc.KeyPair) *Node {
 
 	// setup chans
 	node.in = make(chan api.Msg)
-	node.out = make(chan api.Msg)
+	node.out = make(chan api.Msg, OutBufferSize)
 	node.events = make(chan api.Event)
 
 	// setup default router

--- a/nodes/fs/fsnode.go
+++ b/nodes/fs/fsnode.go
@@ -13,6 +13,8 @@ import (
 	"github.com/awgh/ratnet/router"
 )
 
+var OutBufferSize = 128
+
 type outboxMsg struct {
 	channel   string
 	msg       []byte
@@ -68,7 +70,7 @@ func New(contentKey, routingKey bc.KeyPair, basePath string) *Node {
 
 	// setup chans
 	node.in = make(chan api.Msg)
-	node.out = make(chan api.Msg)
+	node.out = make(chan api.Msg, OutBufferSize)
 	node.events = make(chan api.Event)
 
 	// setup default router

--- a/nodes/qldb/qlnode.go
+++ b/nodes/qldb/qlnode.go
@@ -16,6 +16,8 @@ import (
 	_ "modernc.org/ql/driver" // load the QL database driver
 )
 
+var OutBufferSize = 128
+
 // Node : defines an instance of the API with a ql-DB backed Node
 type Node struct {
 	contentKey  bc.KeyPair
@@ -52,7 +54,7 @@ func New(contentKey, routingKey bc.KeyPair) *Node {
 
 	// setup chans
 	node.in = make(chan api.Msg)
-	node.out = make(chan api.Msg)
+	node.out = make(chan api.Msg, OutBufferSize)
 	node.events = make(chan api.Event)
 
 	// setup default router

--- a/nodes/ram/ramnode.go
+++ b/nodes/ram/ramnode.go
@@ -9,6 +9,8 @@ import (
 	"github.com/awgh/ratnet/router"
 )
 
+var OutBufferSize = 128
+
 // Node : defines an instance of the API with a ql-DB backed Node
 type Node struct {
 	contentKey bc.KeyPair
@@ -69,7 +71,7 @@ func New(contentKey, routingKey bc.KeyPair) *Node {
 
 	// setup chans
 	node.in = make(chan api.Msg)
-	node.out = make(chan api.Msg)
+	node.out = make(chan api.Msg, OutBufferSize)
 	node.events = make(chan api.Event)
 
 	// setup default router


### PR DESCRIPTION
This makes the 'Out' channel of each node buffered, by default using a buffer size of 128. The int that specifies the buffer size is exported, so the buffer size is configurable for advanced users.