### PR TITLE
Fix 'isRunning' race condition

### DIFF
--- a/nodes/db/dbnode.go
+++ b/nodes/db/dbnode.go
@@ -6,6 +6,7 @@ package db
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/awgh/bencrypt/bc"
 	"github.com/awgh/ratnet/api"
@@ -29,7 +30,7 @@ type Node struct {
 
 	mutex *sync.Mutex
 
-	isRunning bool
+	isRunning uint32
 
 	debugMode bool
 
@@ -61,6 +62,19 @@ func New(contentKey, routingKey bc.KeyPair) *Node {
 	node.router = router.NewDefaultRouter()
 
 	return node
+}
+
+func (node *Node) getIsRunning() bool {
+	return atomic.LoadUint32(&node.isRunning) == 1
+}
+
+func (node *Node) setIsRunning(b bool) {
+	var running uint32 = 0
+	if b {
+		running = 1
+	}
+
+	atomic.StoreUint32(&node.isRunning, running)
 }
 
 // GetPolicies : returns the array of Policy objects for this Node

--- a/nodes/db/importer.go
+++ b/nodes/db/importer.go
@@ -55,7 +55,7 @@ type ImportedNode struct {
 // Import : Load a node configuration from a JSON config
 func (node *Node) Import(jsonConfig []byte) error {
 	restartNode := false
-	if node.isRunning {
+	if node.getIsRunning() {
 		node.Stop()
 		restartNode = true
 	}

--- a/nodes/fs/fsnode.go
+++ b/nodes/fs/fsnode.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"github.com/awgh/bencrypt/bc"
@@ -28,7 +29,7 @@ type Node struct {
 
 	policies  []api.Policy
 	router    api.Router
-	isRunning bool
+	isRunning uint32
 	debugMode bool
 
 	// external data members
@@ -80,6 +81,19 @@ func New(contentKey, routingKey bc.KeyPair, basePath string) *Node {
 	os.Mkdir(basePath, 0700)
 
 	return node
+}
+
+func (node *Node) getIsRunning() bool {
+	return atomic.LoadUint32(&node.isRunning) == 1
+}
+
+func (node *Node) setIsRunning(b bool) {
+	var running uint32 = 0
+	if b {
+		running = 1
+	}
+
+	atomic.StoreUint32(&node.isRunning, running)
 }
 
 func hex(n uint32) string {

--- a/nodes/fs/importer.go
+++ b/nodes/fs/importer.go
@@ -55,7 +55,7 @@ type ImportedNode struct {
 // Import : Load a node configuration from a JSON config
 func (node *Node) Import(jsonConfig []byte) error {
 	restartNode := false
-	if node.isRunning {
+	if node.getIsRunning() {
 		node.Stop()
 		restartNode = true
 	}

--- a/nodes/qldb/admin.go
+++ b/nodes/qldb/admin.go
@@ -303,10 +303,10 @@ func (node *Node) sendBulk(channelName string, destkey bc.PubKey, msg [][]byte) 
 // Start : starts the Connection Policy threads
 func (node *Node) Start() error {
 	// do not start again if the node is already running
-	if node.isRunning {
+	if node.getIsRunning() {
 		return nil
 	}
-	node.isRunning = true
+	node.setIsRunning(true)
 
 	// start the signal monitor
 	node.signalMonitor()
@@ -322,17 +322,8 @@ func (node *Node) Start() error {
 
 	// input loop
 	go func() {
-		for {
-			// check if we should stop running
-			if !node.isRunning {
-				break
-			}
-
-			// read message off the input channel
-			message, more := <-node.In()
-			if !more {
-				break
-			}
+		// read message off the input channel
+		for message := range node.In() {
 			if err := node.SendMsg(message); err != nil {
 				events.Error(node, err.Error())
 			}
@@ -344,7 +335,7 @@ func (node *Node) Start() error {
 		for {
 			time.Sleep(10 * time.Millisecond)
 			// check if we should stop running
-			if !node.isRunning {
+			if !node.getIsRunning() {
 				break
 			}
 			// get all streams
@@ -392,7 +383,7 @@ func (node *Node) Start() error {
 
 // Stop : sets the isRunning flag to false, indicating that all go routines should end
 func (node *Node) Stop() {
-	node.isRunning = false
+	node.setIsRunning(false)
 	for _, policy := range node.policies {
 		policy.Stop()
 	}

--- a/nodes/qldb/qlnode.go
+++ b/nodes/qldb/qlnode.go
@@ -7,6 +7,7 @@ package qldb
 import (
 	"database/sql"
 	"sync"
+	"sync/atomic"
 
 	"github.com/awgh/bencrypt/bc"
 	"github.com/awgh/ratnet/api"
@@ -29,7 +30,7 @@ type Node struct {
 	db       func() *sql.DB
 	mutex    *sync.Mutex
 
-	isRunning bool
+	isRunning uint32
 
 	debugMode bool
 
@@ -61,6 +62,19 @@ func New(contentKey, routingKey bc.KeyPair) *Node {
 	node.router = router.NewDefaultRouter()
 
 	return node
+}
+
+func (node *Node) getIsRunning() bool {
+	return atomic.LoadUint32(&node.isRunning) == 1
+}
+
+func (node *Node) setIsRunning(b bool) {
+	var running uint32 = 0
+	if b {
+		running = 1
+	}
+
+	atomic.StoreUint32(&node.isRunning, running)
 }
 
 // GetPolicies : returns the array of Policy objects for this Node

--- a/nodes/ram/admin.go
+++ b/nodes/ram/admin.go
@@ -315,7 +315,7 @@ func (node *Node) SendMsg(msg api.Msg) error {
 // Start : starts the Connection Policy threads
 func (node *Node) Start() error {
 	// do not start again if the node is already running
-	if node.isRunning {
+	if node.getIsRunning() {
 		return nil
 	}
 
@@ -341,18 +341,12 @@ func (node *Node) Start() error {
 		}
 	}
 
-	node.isRunning = true
+	node.setIsRunning(true)
 
 	// input loop
 	go func() {
-		for {
-			// check if we should stop running
-			if !node.isRunning {
-				break
-			}
-
-			// read message off the input channel
-			message := <-node.In()
+		// read message off the input channel
+		for message := range node.In() {
 			events.Debug(node, "Message accepted on input channel")
 			if err := node.SendMsg(message); err != nil {
 				events.Error(node, err.Error())
@@ -365,7 +359,7 @@ func (node *Node) Start() error {
 		for {
 			time.Sleep(10 * time.Millisecond)
 			// check if we should stop running
-			if !node.isRunning {
+			if !node.getIsRunning() {
 				break
 			}
 			// for each stream, count chunks for that header
@@ -413,8 +407,8 @@ func (node *Node) Start() error {
 
 // Stop : sets the isRunning flag to false, indicating that all go routines should end
 func (node *Node) Stop() {
+	node.setIsRunning(false)
 	for _, policy := range node.policies {
 		policy.Stop()
 	}
-	node.isRunning = false
 }

--- a/nodes/ram/importer.go
+++ b/nodes/ram/importer.go
@@ -55,7 +55,7 @@ type ImportedNode struct {
 // Import : Load a node configuration from a JSON config
 func (node *Node) Import(jsonConfig []byte) error {
 	restartNode := false
-	if node.isRunning {
+	if node.getIsRunning() {
 		node.Stop()
 		restartNode = true
 	}

--- a/nodes/ram/ramnode.go
+++ b/nodes/ram/ramnode.go
@@ -1,6 +1,8 @@
 package ram
 
 import (
+	"sync/atomic"
+
 	"github.com/awgh/bencrypt/ecc"
 
 	"github.com/awgh/bencrypt/bc"
@@ -18,8 +20,8 @@ type Node struct {
 
 	policies []api.Policy
 	router   api.Router
-	//firstRun  bool
-	isRunning bool
+
+	isRunning uint32
 
 	debugMode bool
 
@@ -79,6 +81,19 @@ func New(contentKey, routingKey bc.KeyPair) *Node {
 	node.outbox.node = node
 
 	return node
+}
+
+func (node *Node) getIsRunning() bool {
+	return atomic.LoadUint32(&node.isRunning) == 1
+}
+
+func (node *Node) setIsRunning(b bool) {
+	var running uint32 = 0
+	if b {
+		running = 1
+	}
+
+	atomic.StoreUint32(&node.isRunning, running)
 }
 
 // GetPolicies : returns the array of Policy objects for this Node


### PR DESCRIPTION
Every node has a field `isRunning`, which is a bool that is internally used to check if the node is running or not. A few spawned goroutines constantly check the value of this field, causing a race condition when `node.Stop` is called, as it sets `isRunning` to `false`. 

This race condition is pretty harmless, but shows up when testing with the race detector on, so figured I might as well fix it so I can find race conditions in my code easier.