### PR TITLE
policy/p2p: prevent goroutine race

### DIFF
--- a/policy/p2p/p2p.go
+++ b/policy/p2p/p2p.go
@@ -125,8 +125,8 @@ func (s *P2P) RunPolicy() error {
 	s.setIsAdvertising(true)
 
 	go s.mdnsListen()
+	s.wg.Add(1)
 	go func() {
-		s.wg.Add(1)
 		defer s.wg.Done()
 		for s.IsListening() {
 			if s.IsAdvertising() {


### PR DESCRIPTION
This moves a waitgroup `Add()` out of a goroutine to prevent a race condition.